### PR TITLE
Make square aura icons actually square

### DIFF
--- a/NeatPlatesWidgets/AuraWidget.lua
+++ b/NeatPlatesWidgets/AuraWidget.lua
@@ -591,7 +591,7 @@ local function TransformSquareAura(frame)
 	frame.Parent:SetWidth(DebuffColumns*(16 + 5))
 
 	frame:SetWidth(16.5)
-	frame:SetHeight(14.5)
+	frame:SetHeight(16.5)
 	-- Icon
 	frame.Icon:SetAllPoints(frame)
 	frame.Border:ClearAllPoints()


### PR DESCRIPTION
Was probably an oversight for "Square" and "Blizzlike" style aura icons, as they weren't perfectly square.