### PR TITLE
Use correct scale factor for default friendly nameplates

### DIFF
--- a/NeatPlates/NeatPlatesCore.lua
+++ b/NeatPlates/NeatPlatesCore.lua
@@ -276,7 +276,7 @@ local function UpdateNameplateSize(plate, show, cWidth, cHeight)
 				if NEATPLATES_IS_CLASSIC then
 					SetNamePlateFriendlySize(128 * horizontalScale, 45 * Lerp(1.0, 1.25, zeroBasedScale))
 				else
-					SetNamePlateFriendlySize(145 * horizontalScale, 45 * Lerp(1.0, 1.25, zeroBasedScale))
+					SetNamePlateFriendlySize(110 * horizontalScale, 45 * Lerp(1.0, 1.25, zeroBasedScale))
 				end
 			else SetNamePlateFriendlySize(hitbox.width * scaleStandard, hitbox.height * scaleStandard) end -- Clickable area of the nameplate
 			SetNamePlateEnemySize(hitbox.width * scaleStandard, hitbox.height * scaleStandard) -- Clickable area of the nameplate


### PR DESCRIPTION
NeatPlates has an option to use Blizzard nameplates for friendly targets. It uses the default Blizzard CVars to determine the nameplates' width and height. These CVars are multiplied by scale factors to compute the final size. However, for Retail, the incorrect horizontal scale factor was being applied to the nameplates, causing them to be around 32% wider compared to the base UI. This pull request fixes the issue.